### PR TITLE
removing the use of basename for history, since it's not needed for hash history

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,8 @@ import reducer from './reducers';
 import * as types from './constants/actionTypes';
 
 const browserHistory = useBasename(createHashHistory)({
-  basename: process.env.PUBLIC_URL, // eslint-disable-line no-process-env
+  // no basename is necessary with hash history
+  basename: '/', // process.env.PUBLIC_URL, // eslint-disable-line no-process-env
   hashType: 'slash'
 });
 


### PR DESCRIPTION
#18 